### PR TITLE
Fixed bug with the material overlay component

### DIFF
--- a/projects/common/src/lib/services/theming/theme-color-picker.utils.ts
+++ b/projects/common/src/lib/services/theming/theme-color-picker.utils.ts
@@ -34,7 +34,9 @@ export class ThemeColorPickerService {
 
     public SetColorClass(className: string) {
         this.overlayContainer.getContainerElement().classList.forEach(css => {
+          if (css !== 'cdk-overlay-container') {
             this.overlayContainer.getContainerElement().classList.remove(css);
+          }
         });
 
         this.overlayContainer.getContainerElement().classList.add(className);


### PR DESCRIPTION
Fixed bug where the material overlay component (i.e. tooltips) was breaking when changing themes on the fly.